### PR TITLE
Fix wrong filepath in init/processmonitor.conf

### DIFF
--- a/masakari-processmonitor/init/processmonitor.conf
+++ b/masakari-processmonitor/init/processmonitor.conf
@@ -20,7 +20,7 @@ stop on runlevel [!2345]
 respawn
 
 pre-start script
-    process_name="/opt/rc_process_monitor/rc_process_monitor.sh"
+    process_name="/opt/processmonitor/processmonitor.sh"
     script_name=`basename $process_name`
     cnt=`ps -aef | grep -v grep | grep "$process_name" | wc -l`
     if [ $cnt -ne 0 ]; then
@@ -30,7 +30,7 @@ end script
 
 script
     user="openstack"
-    process_name="/opt/rc_process_monitor/rc_process_monitor.sh"
+    process_name="/opt/processmonitor/processmonitor.sh"
     exec su - $user -c "$process_name"
 end script
 


### PR DESCRIPTION
Fix wrong filepath "/opt/rc_process_monitor/rc_process_monitor.sh" to "/opt/processmonitor/processmonitor.sh".

After applying this change, I became possible to start processmonitor service.
