### PR TITLE
Fix instancemonitor init.d

### DIFF
--- a/masakari-instancemonitor/init.d/masakari-instancemonitor
+++ b/masakari-instancemonitor/init.d/masakari-instancemonitor
@@ -21,7 +21,7 @@
 
 PROGNAME=masakari-instancemonitor
 PROG_DIR=/opt/masakari/instancemonitor
-PROG=$PROG_DIR/masakari-instancemonitor.py
+PROG=$PROG_DIR/masakari_instancemonitor.py
 PIDFILE=/var/run/masakari-instancemonitor.pid
 PYTHON=/usr/bin/python
 USER=openstack

--- a/masakari-processmonitor/etc/proc.list.sample
+++ b/masakari-processmonitor/etc/proc.list.sample
@@ -1,2 +1,2 @@
 01,/usr/sbin/libvirtd,sudo service libvirt-bin start,sudo service libvirt-bin start,,,,
-02,/usr/bin/python -u /opt/masakari/instancemonitor/masakari-instancemonitor.py,sudo service masakari-instancemonitor start,sudo service masakari-instancemonitor start,,,,
+02,/usr/bin/python -u /opt/masakari/instancemonitor/masakari_instancemonitor.py,sudo service masakari-instancemonitor start,sudo service masakari-instancemonitor start,,,,


### PR DESCRIPTION
File name of instancemonitor is 'masakari_instancemonitor.py' not
'masakari-instancemonitor.py'.  The inconsistency causes service starting error.
