### PR TITLE
Fix the instancemonitor deb packaging

### DIFF
--- a/masakari-instancemonitor/debian/postinst
+++ b/masakari-instancemonitor/debian/postinst
@@ -3,8 +3,9 @@ set -e
 ucf /etc/masakari/masakari-instancemonitor.conf.sample /etc/masakari/masakari-instancemonitor.conf
 LOG_DIR=/var/log/masakari
 if [ -z "`dpkg-statoverride --list ${LOG_DIR}`" ] ; then dpkg-statoverride --update --add openstack openstack 0755 ${LOG_DIR}; fi
-dpkg-statoverride --update --add openstack openstack 0755 /opt/masakari/instancemonitor/masakari-instancemonitor.py
+dpkg-statoverride --update --add openstack openstack 0755 /opt/masakari/instancemonitor/masakari_instancemonitor.py
 dpkg-statoverride --update --add openstack openstack 0644 /opt/masakari/instancemonitor/libvirt_eventfilter.py
 dpkg-statoverride --update --add openstack openstack 0644 /opt/masakari/instancemonitor/libvirt_eventfilter_table.py
 dpkg-statoverride --update --add openstack openstack 0644 /opt/masakari/instancemonitor/libvirt_callback.py
+dpkg-statoverride --update --add openstack openstack 0644 /opt/masakari/instancemonitor/__init__.py
 exit 0

--- a/masakari-instancemonitor/debian/postrm
+++ b/masakari-instancemonitor/debian/postrm
@@ -1,8 +1,9 @@
 #! /bin/sh
 set -e
 ucf --purge /etc/masakari/masakari-instancemonitor.conf
-dpkg-statoverride --remove /opt/masakari/instancemonitor/masakari-instancemonitor.py
+dpkg-statoverride --remove /opt/masakari/instancemonitor/masakari_instancemonitor.py
 dpkg-statoverride --remove /opt/masakari/instancemonitor/libvirt_eventfilter.py
 dpkg-statoverride --remove /opt/masakari/instancemonitor/libvirt_eventfilter_table.py
 dpkg-statoverride --remove /opt/masakari/instancemonitor/libvirt_callback.py
+dpkg-statoverride --remove /opt/masakari/instancemonitor/__init__.py
 exit 0


### PR DESCRIPTION
Need change masakari-instancemonitor to masakari_instancemonitor in
postinst  and postrm in debian packaging.
Add postinst (dpkg-statoverride) and postrm for **init**.py also.
