### PR TITLE
Add pytz in requirements.txt

### DIFF
--- a/masakari-controller/requirements.txt
+++ b/masakari-controller/requirements.txt
@@ -1,4 +1,5 @@
 # MySQL-python still used in utils/*.py scripts
+pytz>=2016.3
 MySQL-python>=1.2.5
 argparse>=1.2.1
 ecdsa>=0.13


### PR DESCRIPTION
When you deploy masakari with setup.py pytz is required. Additionally, masakari-deploy fails to deploy masakari if it's not in requirements.txt.
