### PR TITLE
TrivialFix: modify typo in build sequence doc.

### DIFF
--- a/masakari-controller/rpmbuild/howtobuild_rpms.txt
+++ b/masakari-controller/rpmbuild/howtobuild_rpms.txt
@@ -13,11 +13,11 @@ $mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 $cd masakari
 $tar czvf masakari-controller.tar.gz masakari-controller --exclude='masakari-controller/debian' --exclude='masakari-controller/rpmbuild'
-mv masakari-controller.tar.gz ~/rpmbuild/SOURCES/
-cp masakari-controller/rpmbuild/SPECS/processmonitor.spec ~/rpmbuild/SPECS/
-cd ~/rpmbuild/SPECS/
-rpmbuild --bb hostmonitor.spec
+$mv masakari-controller.tar.gz ~/rpmbuild/SOURCES/
+$cp masakari-controller/rpmbuild/SPECS/masakari-controller.spec ~/rpmbuild/SPECS/
+$cd ~/rpmbuild/SPECS/
+$rpmbuild --bb masakari-controller.spec
 
 rpms are in,
-cd ~/rpmbuild/RPMS/ARCH
+$ls -l ~/rpmbuild/RPMS/<ARCH>
 # Substitute "ARCH" for your architecture

--- a/masakari-hostmonitor/rpmbuild/howtobuild_rpms.txt
+++ b/masakari-hostmonitor/rpmbuild/howtobuild_rpms.txt
@@ -13,11 +13,11 @@ $mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 $cd masakari
 $tar czvf masakari-hostmonitor.tar.gz masakari-hostmonitor --exclude='masakari-hostmonitor/debian' --exclude='masakari-hostmonitor/rpmbuild'
-mv masakari-hostmonitor.tar.gz ~/rpmbuild/SOURCES/
-cp masakari-hostmonitor/rpmbuild/SPECS/processmonitor.spec ~/rpmbuild/SPECS/
-cd ~/rpmbuild/SPECS/
-rpmbuild --bb hostmonitor.spec
+$mv masakari-hostmonitor.tar.gz ~/rpmbuild/SOURCES/
+$cp masakari-hostmonitor/rpmbuild/SPECS/hostmonitor.spec ~/rpmbuild/SPECS/
+$cd ~/rpmbuild/SPECS/
+$rpmbuild --bb hostmonitor.spec
 
 rpms are in,
-cd ~/rpmbuild/RPMS/ARCH
+$ls -l ~/rpmbuild/RPMS/<ARCH>
 # Substitute "ARCH" for your architecture

--- a/masakari-instancemonitor/rpmbuild/howtobuild_rpms.txt
+++ b/masakari-instancemonitor/rpmbuild/howtobuild_rpms.txt
@@ -13,11 +13,11 @@ $mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 $cd masakari
 $tar czvf masakari-instancemonitor.tar.gz masakari-instancemonitor --exclude='masakari-instancemonitor/debian' --exclude='masakari-instancemonitor/rpmbuild'
-mv masakari-instancemonitor.tar.gz ~/rpmbuild/SOURCES/
-cp masakari-instancemonitor/rpmbuild/SPECS/processmonitor.spec ~/rpmbuild/SPECS/
-cd ~/rpmbuild/SPECS/
-rpmbuild --bb instancemonitor.spec
+$mv masakari-instancemonitor.tar.gz ~/rpmbuild/SOURCES/
+$cp masakari-instancemonitor/rpmbuild/SPECS/masakari-instancemonitor.spec ~/rpmbuild/SPECS/
+$cd ~/rpmbuild/SPECS/
+$rpmbuild --bb masakari-instancemonitor.spec
 
 rpms are in,
-cd ~/rpmbuild/RPMS/ARCH
+$ls -l ~/rpmbuild/RPMS/<ARCH>
 # Substitute "ARCH" for your architecture

--- a/masakari-processmonitor/rpmbuild/howtobuild_rpms.txt
+++ b/masakari-processmonitor/rpmbuild/howtobuild_rpms.txt
@@ -13,11 +13,11 @@ $mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 $cd masakari
 $tar czvf masakari-processmonitor.tar.gz masakari-processmonitor --exclude='masakari-processmonitor/debian' --exclude='masakari-processmonitor/rpmbuild'
-mv masakari-processmonitor.tar.gz ~/rpmbuild/SOURCES/
-cp masakari-processmonitor/rpmbuild/SPECS/processmonitor.spec ~/rpmbuild/SPECS/
-cd ~/rpmbuild/SPECS/
-rpmbuild --bb hostmonitor.spec
+$mv masakari-processmonitor.tar.gz ~/rpmbuild/SOURCES/
+$cp masakari-processmonitor/rpmbuild/SPECS/processmonitor.spec ~/rpmbuild/SPECS/
+$cd ~/rpmbuild/SPECS/
+$rpmbuild --bb processmonitor.spec
 
 rpms are in,
-cd ~/rpmbuild/RPMS/ARCH
+$ls -l ~/rpmbuild/RPMS/<ARCH>
 # Substitute "ARCH" for your architecture


### PR DESCRIPTION
Correct spec file name in howtobuild_rpms.txt.