### PR TITLE
Fix checking records in vm_list

### DIFF
--- a/masakari-controller/controller/masakari_starter.py
+++ b/masakari-controller/controller/masakari_starter.py
@@ -167,16 +167,16 @@ class RecoveryControllerStarter(object):
 
             msg = "Do get_one_vm_list_by_uuid_and_progress_create_at_last."
             LOG.info(msg)
-            row_cnt = dbapi.get_one_vm_list_by_uuid_and_progress_create_at_last(
+            result = dbapi.get_one_vm_list_by_uuid_and_progress_create_at_last(
                 session,
                 notification_uuid)
             msg = "Succeeded in " \
                 + "get_one_vm_list_by_uuid_and_progress_create_at_last. " \
-                + "Return_value = " + str(row_cnt)
+                + "Return_value = " + str(result)
             LOG.info(msg)
 
             primary_id = None
-            if row_cnt == 0:
+            if not result:
                 primary_id = self.rc_util_db.insert_vm_list_db(
                     session, notification_id, notification_uuid, 0)
 


### PR DESCRIPTION
This pull request shortens the time to ecavuate invocation.
On my environment, this PR shortens by 60 seconds (`recovery_max_retry_count(6) * recovery_retry_interval(10)`).

`dbapi.get_one_vm_list_by_uuid_and_progress_create_at_last` returns not `0` but `None` in case of no record. So I'v changed from `if row_cnt == 0` to `if not result` in `_create_vm_list_db_for_failed_host` like `_create_vm_list_db_for_failed_instance`.
